### PR TITLE
Macro to generate component functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,24 @@ end
 
 If your component is in a directory, for example `assets/svelte/some-directory/SomeComponent.svelte` you need to include the directory in your name: `some-directory/SomeComponent`.
 
+### The Components Macro 
+
+There is also an Elixir macro which checks your `assets/svelte` folder for any Svelte components, and injects local function `def`s for those components into the calling module.
+
+This allows for an alternative, more JSX-like authoring experience inside Liveviews.
+
+e.g. in the below example, a Svelte component called `Example` is available to be called inside the Liveview template:
+
+```elixir
+use LiveSvelte.Components 
+
+def render(assigns) do
+  ~H"""
+  <.Example number={@number} />
+  """
+end
+```
+
 ### Examples
 
 Examples can be found in the `/examples` and `/example_project` directories.

--- a/example_project/lib/example_web/live/live_chat.ex
+++ b/example_project/lib/example_web/live/live_chat.ex
@@ -1,5 +1,6 @@
 defmodule ExampleWeb.LiveExample6 do
   use ExampleWeb, :live_view
+  use LiveSvelte.Macros
 
   @topic "public"
   @event_new_message "new_message"
@@ -21,10 +22,10 @@ defmodule ExampleWeb.LiveExample6 do
           <button class="py-2 px-4 bg-black text-white rounded">Join</button>
         </form>
       <% else %>
-        <.svelte
-          name="Chat"
-          props={%{messages: @messages, name: @name}}
-          class="w-full h-full flex justify-center items-center"
+        <.Chat
+            messages={@messages}
+            name={@name}
+            class="w-full h-full flex justify-center items-center"
         />
       <% end %>
     </div>

--- a/example_project/lib/example_web/live/live_chat.ex
+++ b/example_project/lib/example_web/live/live_chat.ex
@@ -1,6 +1,6 @@
 defmodule ExampleWeb.LiveExample6 do
   use ExampleWeb, :live_view
-  use LiveSvelte.Macros
+  use LiveSvelte.Components
 
   @topic "public"
   @event_new_message "new_message"

--- a/example_project/lib/example_web/live/live_chat.ex
+++ b/example_project/lib/example_web/live/live_chat.ex
@@ -8,26 +8,24 @@ defmodule ExampleWeb.LiveExample6 do
   def render(assigns) do
     ~H"""
     <div class="flex justify-center items-center h-full w-full">
-      <%= if !@name do %>
-        <form phx-submit="set_name">
-          <!-- svelte-ignore a11y-autofocus -->
-          <input
-            type="text"
-            placeholder="Name"
-            name="name"
-            class="rounded"
-            autofocus
-            autocomplete="name"
-          />
-          <button class="py-2 px-4 bg-black text-white rounded">Join</button>
-        </form>
-      <% else %>
-        <.Chat
-            messages={@messages}
-            name={@name}
-            class="w-full h-full flex justify-center items-center"
+      <form phx-submit="set_name" :if={!@name}>
+        <!-- svelte-ignore a11y-autofocus -->
+        <input
+          type="text"
+          placeholder="Name"
+          name="name"
+          class="rounded"
+          autofocus
+          autocomplete="name"
         />
-      <% end %>
+        <button class="py-2 px-4 bg-black text-white rounded">Join</button>
+      </form>
+      <.Chat
+          messages={@messages}
+          name={@name}
+          class="w-full h-full flex justify-center items-center"
+          :if={@name}
+      />
     </div>
     """
   end

--- a/example_project/lib/example_web/live/live_counter_hybrid.ex
+++ b/example_project/lib/example_web/live/live_counter_hybrid.ex
@@ -1,11 +1,12 @@
 defmodule ExampleWeb.LiveExample3 do
   use ExampleWeb, :live_view
+  use LiveSvelte.Components
 
   def render(assigns) do
     ~H"""
     <h1 class="flex justify-center mb-10 font-bold">Hybrid: LiveView + Svelte</h1>
 
-    <.svelte name="CounterHybrid" props={%{number: @number}} />
+    <.CounterHybrid number={@number} />
     """
   end
 

--- a/lib/components.ex
+++ b/lib/components.ex
@@ -33,22 +33,23 @@ defmodule LiveSvelte.Components do
           assigns
           |> Map.filter(fn
             {:svelte_opts, _v} -> false
-            {k, _v} -> k not in [:__changed__]
+            {k, _v} -> k not in [:__changed__, :__given__, :ssr]
             _ -> false
           end)
 
         var!(assigns) =
-          assign(assigns,
-            __component_name: unquote(name),
-            props: props || %{}
-          )
+          assigns
+          |> Map.put(:__component_name, unquote(name))
+          |> Map.put_new(:ssr, true)
+          |> Map.put_new(:class, nil)
+          |> assign(:props, props)
 
         ~H"""
         <LiveSvelte.svelte
-          name={Map.get(var!(assigns), :__component_name)}
-          class={Map.get(var!(assigns), :class)}
-          ssr={LiveSvelte.get_ssr(var!(assigns))}
-          props={Map.get(var!(assigns), :props, %{})}
+          name={@__component_name}
+          class={@class}
+          ssr={@ssr}
+          props={@props}
         />
         """
       end

--- a/lib/components.ex
+++ b/lib/components.ex
@@ -1,4 +1,4 @@
-defmodule LiveSvelte.Macros do
+defmodule LiveSvelte.Components do
   @moduledoc """
   Macros to improve the developer experience of crossing the Liveview/Svelte boundary.
   """

--- a/lib/macros.ex
+++ b/lib/macros.ex
@@ -29,7 +29,7 @@ defmodule LiveSvelte.Macros do
           <LiveSvelte.svelte
             name={Map.get(var!(assigns), :__component_name)}
             class={Map.get(var!(assigns), :class)}
-            ssr={false}
+            ssr={LiveSvelte.get_ssr(var!(assigns)) |> IO.inspect(label: "ssr")}
             props={Map.get(var!(assigns), :props, %{})}
           />
           """

--- a/lib/macros.ex
+++ b/lib/macros.ex
@@ -1,0 +1,55 @@
+defmodule LiveSvelte.Macros do
+  @moduledoc """
+  Macros to improve the developer experience of crossing the Liveview/Svelte boundary.
+  """
+
+  @doc """
+  Generates functions local to your current module that can be used to render Svelte components.
+  """
+  defmacro __using__(_opts) do
+    get_svelte_components()
+    |> Enum.map(fn name ->
+      quote do
+        def unquote(:"#{name}")(assigns) do
+          props =
+            assigns
+            |> Map.filter(fn
+              {:svelte_opts, _v} -> false
+              {k, _v} -> k not in [:__changed__]
+              _ -> false
+            end)
+
+          var!(assigns) =
+            assign(assigns,
+              __component_name: unquote(name),
+              props: props || %{}
+            )
+
+          ~H"""
+          <LiveSvelte.svelte
+            name={Map.get(var!(assigns), :__component_name)}
+            class={Map.get(var!(assigns), :class)}
+            ssr={false}
+            props={Map.get(var!(assigns), :props, %{})}
+          />
+          """
+        end
+      end
+    end)
+  end
+
+  @doc """
+  TODO: This could perhaps be optimized to only read the files once per compilation.
+  """
+  def get_svelte_components do
+    "./assets/svelte/"
+    |> Path.join("**/*.svelte")
+    |> Path.wildcard()
+    |> Enum.filter(&(not String.contains?(&1, "_build/")))
+    |> Enum.map(fn path ->
+      path
+      |> Path.basename()
+      |> String.replace(".svelte", "")
+    end)
+  end
+end


### PR DESCRIPTION
## Changes 

This PR creates an experimental macro which checks the `assets/svelte` folder for any Svelte components, and injects local function `def`s for those components into the calling module. 

My thinking is that this would provide a _cleaner_ more ergonomic interface into Svelte from Liveview, with a better DX. In the future `attr` macros could even be generated based on Svelte component exports. 

## Usage 

```elixir
def MyModule do
  use LiveSvelte.Components

  def render(assigns) do
    ~H"""
    <.MySvelteComponent foo="123" bar={456} />
    """
  end
end
```

## Examples

See the live_chat file at example_project/lib/example_web/live/live_chat.ex in the example project for a working example! 

## Caveats 

The `assets/svelte` directory is parsed once per module which calls `use LiveSvelte.Components`. A future improvement would be to only check here once per compile, and then reference the previously generated functions. 

