### PR TITLE
Fix some small issues

### DIFF
--- a/assets/copy/build.js
+++ b/assets/copy/build.js
@@ -10,11 +10,11 @@ const deploy = args.includes("--deploy")
 let optsClient = {
     entryPoints: ["js/app.js"],
     bundle: true,
+    minify: deploy,
     target: "es2017",
     conditions: ["svelte"],
     outdir: "../priv/static/assets",
     logLevel: "info",
-    minify: deploy,
     sourcemap: watch ? "inline" : false,
     watch,
     tsconfig: "./tsconfig.json",
@@ -22,7 +22,7 @@ let optsClient = {
         importGlobPlugin(),
         sveltePlugin({
             preprocess: sveltePreprocess(),
-            compilerOptions: {hydratable: true, css: true},
+            compilerOptions: {hydratable: true, css: 'injected'},
         }),
     ],
 }

--- a/assets/js/live_svelte/hooks.js
+++ b/assets/js/live_svelte/hooks.js
@@ -2,7 +2,7 @@ import {detach, insert, noop} from "svelte/internal"
 import {exportSvelteComponents} from "./utils"
 
 function base64ToElement(base64) {
-    let template = document.createElement("div")
+    const template = document.createElement("div")
     template.innerHTML = atob(base64).trim()
     return template
 }
@@ -52,15 +52,15 @@ function createSlots(slots, ref) {
 }
 
 function getLiveJsonProps(ref) {
-    json = dataAttributeToJson("data-live-json", ref.el)
+    const json = dataAttributeToJson("data-live-json", ref.el)
 
     // On SSR, data-live-json is the full object we want
     // After SSR, data-live-json is an array of keys, and we'll get the data from the window
     if (typeof json === "object" && json !== null && !Array.isArray(json)) return json
 
-    liveJsonData = {}
+    const liveJsonData = {}
     for (const liveJsonVariable of json) {
-        let data = window[liveJsonVariable]
+        const data = window[liveJsonVariable]
         if (data) liveJsonData[liveJsonVariable] = data
     }
     return liveJsonData
@@ -106,7 +106,7 @@ export function getHooks(Components) {
             this._instance = new Component({
                 target: this.el,
                 props: getProps(this),
-                hydrate: true,
+                hydrate: this.el.hasAttribute("data-ssr"),
             })
         },
 

--- a/example_project/assets/build.js
+++ b/example_project/assets/build.js
@@ -10,11 +10,11 @@ const deploy = args.includes("--deploy")
 let optsClient = {
     entryPoints: ["js/app.js"],
     bundle: true,
+    minify: deploy,
     target: "es2017",
-    conditions: ["svelte", "default"],
+    conditions: ["svelte"],
     outdir: "../priv/static/assets",
     logLevel: "info",
-    minify: deploy,
     sourcemap: watch ? "inline" : false,
     watch,
     tsconfig: "./tsconfig.json",
@@ -22,7 +22,7 @@ let optsClient = {
         importGlobPlugin(),
         sveltePlugin({
             preprocess: sveltePreprocess(),
-            compilerOptions: {hydratable: true, css: true},
+            compilerOptions: {hydratable: true, css: 'injected'},
         }),
     ],
 }
@@ -31,9 +31,9 @@ let optsServer = {
     entryPoints: ["js/server.js"],
     platform: "node",
     bundle: true,
-    conditions: ["svelte", "default"],
     minify: false,
     target: "node19.6.1",
+    conditions: ["svelte"],
     outdir: "../priv/static/assets/server",
     logLevel: "info",
     sourcemap: watch ? "inline" : false,

--- a/lib/component.ex
+++ b/lib/component.ex
@@ -54,7 +54,7 @@ defmodule LiveSvelte do
   Renders a Svelte component on the server.
   """
   def svelte(assigns) do
-    init = Map.get(assigns, :__changed__, nil) == nil
+    init = Map.get(assigns, :__changed__) == nil
 
     slots =
       assigns
@@ -89,6 +89,7 @@ defmodule LiveSvelte do
         id={id(@name)}
         data-name={@name}
         data-props={json(@props)}
+        data-ssr={@ssr_render != nil}
         data-live-json={if @init, do: json(@live_json_props), else: @live_json_props |> Map.keys() |> json()}
         data-slots={Slots.base_encode_64(@slots) |> json}
         phx-update="ignore"

--- a/lib/components.ex
+++ b/lib/components.ex
@@ -15,15 +15,9 @@ defmodule LiveSvelte.Components do
   TODO: This could perhaps be optimized to only read the files once per compilation.
   """
   def get_svelte_components do
-    "./assets/svelte/"
-    |> Path.join("**/*.svelte")
+    "./assets/svelte/*.svelte"
     |> Path.wildcard()
-    |> Enum.filter(&(not String.contains?(&1, "_build/")))
-    |> Enum.map(fn path ->
-      path
-      |> Path.basename()
-      |> String.replace(".svelte", "")
-    end)
+    |> Enum.map(fn path -> Path.basename(path, ".svelte") end)
   end
 
   defp name_to_function(name) do


### PR DESCRIPTION
- `json` and `liveJsonData` variables in `getLiveJsonProps` were missing declaration specifier. The code was not working in strict mode.

- Svelte was complaining about `compilerOptions.css` being boolean in the client config, set it to corresponding proper string value - `injected`.

- `hydrate` should be true only if there was ssr involved, was getting errors about it, added `data-ssr` attribute to indicate server rendering.

- other stuff is just cosmetics, making things consistent.