### PR TITLE
Add "browser" to client esbuild conditions for svelte 4

### DIFF
--- a/assets/copy/build.js
+++ b/assets/copy/build.js
@@ -12,7 +12,7 @@ let optsClient = {
     bundle: true,
     minify: deploy,
     target: "es2017",
-    conditions: ["svelte"],
+    conditions: ["svelte", "browser"],
     outdir: "../priv/static/assets",
     logLevel: "info",
     sourcemap: watch ? "inline" : false,

--- a/example_project/assets/build.js
+++ b/example_project/assets/build.js
@@ -12,7 +12,7 @@ let optsClient = {
     bundle: true,
     minify: deploy,
     target: "es2017",
-    conditions: ["svelte"],
+    conditions: ["svelte", "browser"],
     outdir: "../priv/static/assets",
     logLevel: "info",
     sourcemap: watch ? "inline" : false,


### PR DESCRIPTION
Migration guide for svelte 4 [states](https://svelte.dev/docs/v4-migration-guide#browser-conditions-for-bundlers):

> Bundlers must now specify the browser condition when building a frontend bundle for the browser.