### PR TITLE
Pass live api through context not a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,14 @@ If you have examples you want to add, feel free to create a PR, I'd be happy to 
 
 ```svelte
 <script>
+    import {getLive} from "live_svelte"
+
+    // live contains all exported LiveView methods available to the frontend
+    const live = getLive()
+
     // The number prop is reactive,
     // this means if the server assigns the number, it will update in the frontend
     export let number = 1
-    // live contains all exported LiveView methods available to the frontend
-    export let live
 
     function increase() {
         // This pushes the event over the websocket
@@ -236,7 +239,7 @@ If you have examples you want to add, feel free to create a PR, I'd be happy to 
     }
 
     function decrease() {
-        pushEvent("set_number", {number: number - 1}, () => {})
+        live.pushEvent("set_number", {number: number - 1}, () => {})
     }
 </script>
 

--- a/assets/copy/js/app.js
+++ b/assets/copy/js/app.js
@@ -20,9 +20,12 @@ import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
+import {getContext} from "svelte"
 import topbar from "../vendor/topbar"
-import {getHooks} from "live_svelte"
+import {getHooks, setupLive} from "live_svelte"
 import * as Components from "../svelte/**/*.svelte"
+
+setupLive(getContext)
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 let liveSocket = new LiveSocket("/live", Socket, {hooks: getHooks(Components), params: {_csrf_token: csrfToken}})

--- a/assets/js/live_svelte/hooks.js
+++ b/assets/js/live_svelte/hooks.js
@@ -1,4 +1,4 @@
-import {normalizeComponents} from "./utils"
+import {normalizeComponents, getLive} from "./utils"
 
 function getAttributeJson(ref, attributeName) {
     const data = ref.el.getAttribute(attributeName)
@@ -71,7 +71,6 @@ function getProps(ref) {
     return {
         ...getAttributeJson(ref, "data-props"),
         ...getLiveJsonProps(ref),
-        live: ref,
         $$slots: getSlots(ref),
         $$scope: {},
     }
@@ -83,7 +82,7 @@ function findSlotCtx(component) {
     return component.$$.ctx.find(ctxElement => ctxElement?.default)
 }
 
-export function getHooks(components) {
+export function getHooks(components, options) {
     components = normalizeComponents(components)
 
     const SvelteHook = {
@@ -106,6 +105,7 @@ export function getHooks(components) {
             this._instance = new Component({
                 target: this.el,
                 props: getProps(this),
+                context: new Map([[getLive, this]]),
                 hydrate: this.el.hasAttribute("data-ssr"),
             })
         },

--- a/assets/js/live_svelte/index.js
+++ b/assets/js/live_svelte/index.js
@@ -1,2 +1,3 @@
 export {getRender} from "./render"
 export {getHooks} from "./hooks"
+export {setupLive, getLive} from "./utils"

--- a/assets/js/live_svelte/types.d.ts
+++ b/assets/js/live_svelte/types.d.ts
@@ -11,3 +11,5 @@ export type Live = {
 
 export declare const getHooks: (components: object) => object
 export declare const getRender: (components: object) => (name: string, props: object, slots: object) => any
+export declare const setupLive: (getContext: (key: string) => any) => Live
+export declare const getLive: () => Live

--- a/assets/js/live_svelte/utils.js
+++ b/assets/js/live_svelte/utils.js
@@ -9,3 +9,13 @@ export function normalizeComponents(components) {
     }
     return normalized
 }
+
+let getSvelteContext = undefined
+
+export function setupLive(getContext) {
+    getSvelteContext = getContext
+}
+
+export function getLive() {
+    return getSvelteContext?.(getLive)
+}

--- a/example_project/assets/js/app.js
+++ b/example_project/assets/js/app.js
@@ -20,10 +20,13 @@ import "phoenix_html"
 // Establish Phoenix Socket and LiveView configuration.
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
+import {getContext} from "svelte"
 import topbar from "../vendor/topbar"
 import {createLiveJsonHooks} from "live_json"
-import {getHooks} from "live_svelte"
+import {getHooks, setupLive} from "live_svelte"
 import * as Components from "../svelte/**/*.svelte"
+
+setupLive(getContext)
 
 const Hooks = {
     ...createLiveJsonHooks(),

--- a/example_project/assets/package-lock.json
+++ b/example_project/assets/package-lock.json
@@ -27,7 +27,7 @@
         },
         "..": {},
         "../..": {
-            "version": "0.11.0",
+            "version": "0.12.0",
             "license": "MIT",
             "devDependencies": {
                 "prettier": "2.8.7",

--- a/example_project/assets/svelte/Chat.svelte
+++ b/example_project/assets/svelte/Chat.svelte
@@ -2,10 +2,12 @@
     import {fly} from "svelte/transition"
     import {elasticOut} from "svelte/easing"
     import {afterUpdate} from "svelte"
+    import {getLive} from "live_svelte"
+
+    const live = getLive()
 
     export let messages
     export let name
-    export let live
 
     let body = ""
     let messagesElement

--- a/example_project/assets/svelte/LightControllers.svelte
+++ b/example_project/assets/svelte/LightControllers.svelte
@@ -1,6 +1,10 @@
 <script>
-    export let live
+    import {getLive} from "live_svelte"
+
+    const live = getLive()
+
     export let isOn = false
+
     const toggleLight = () => {
         isOn = !isOn
         live.pushEvent(isOn ? "on" : "off")

--- a/example_project/assets/svelte/LogList.svelte
+++ b/example_project/assets/svelte/LogList.svelte
@@ -1,7 +1,9 @@
 <script>
     import {slide, fly} from "svelte/transition"
+    import {getLive} from "live_svelte"
 
-    export let live
+    const live = getLive()
+
     export let items = []
     let body
     let i = 1

--- a/example_project/lib/example_web/live/live_breaking_news.ex
+++ b/example_project/lib/example_web/live/live_breaking_news.ex
@@ -22,9 +22,11 @@ defmodule ExampleWeb.LiveExample5 do
         import {slide, fly} from "svelte/transition"
         import {Marquee} from "dynamic-marquee"
         import {onMount} from "svelte"
+        import {getLive} from "live_svelte"
+
+        const live = getLive()
 
         export let news = []
-        export let live
 
         let newItem = ""
         let marquee

--- a/examples/advanced_chat/AdvancedChat.svelte
+++ b/examples/advanced_chat/AdvancedChat.svelte
@@ -2,10 +2,12 @@
     import {slide, fly, fade} from "svelte/transition"
     import {elasticOut} from "svelte/easing"
     import {afterUpdate} from "svelte"
+    import {getLive} from "live_svelte"
+
+    const live = getLive()
 
     export let messages
     export let name
-    export let live
 
     let body = ""
     let messagesElement

--- a/examples/animated_number/Numbers.svelte
+++ b/examples/animated_number/Numbers.svelte
@@ -1,8 +1,10 @@
 <script>
     import {fly} from "svelte/transition"
+    import {getLive} from "live_svelte"
+
+    const live = getLive()
 
     export let number = 1
-    export let live
 
     function increase() {
         live.pushEvent("set_number", {number: number + 1})

--- a/examples/breaking_news/BreakingNews.svelte
+++ b/examples/breaking_news/BreakingNews.svelte
@@ -3,9 +3,11 @@
     import {slide, fly} from "svelte/transition"
     import {Marquee} from "dynamic-marquee"
     import {onMount} from "svelte"
+    import {getLive} from "live_svelte"
+
+    const live = getLive()
 
     export let news = []
-    export let live
 
     let newItem = ""
     let marquee

--- a/examples/log_list/LogList.svelte
+++ b/examples/log_list/LogList.svelte
@@ -1,7 +1,9 @@
 <script>
     import {slide, fly} from "svelte/transition"
+    import {getLive} from "live_svelte"
 
-    export let live
+    const live = getLive()
+
     export let items = []
 
     let newItemName

--- a/examples/simple/Simple.svelte
+++ b/examples/simple/Simple.svelte
@@ -1,6 +1,9 @@
 <script>
+    import {getLive} from "live_svelte"
+
+    const live = getLive()
+
     export let number
-    export let live
 
     function increase() {
         live.pushEvent("set_number", {number: number + 1})

--- a/examples/simple_chat/Chat.svelte
+++ b/examples/simple_chat/Chat.svelte
@@ -1,8 +1,10 @@
 <script>
     import {slide} from "svelte/transition"
+    import {getLive} from "live_svelte"
+
+    const live = getLive()
 
     export let messages
-    export let live
 
     let message = ""
     let name = ""


### PR DESCRIPTION
Right now live api is exposed as a prop. And we pass it to all rendered components, even those who do not ask for it, which causes svelte to complain about it.

A viable alternative is to pass it not as a prop, but through context. Which will remove the warnings and ease access for nested components to live api. It is a breaking change through.

```ts
// before
export let live

// after
import {getLive} from "live-svelte"
const live = getLive()
```

`getLive` is typed which is also a bonus.

To make it work, two and half lines with `setupLive` call have to be added to `app.js` (so no action from new users, but migrating users need to add them):

```ts
import {getContext} from "svelte"
import {getHooks, setupLive} from "live_svelte"
setupLive(getContext)
```

**Edit:** updated the description to reflect current state.