### PR TITLE
Fix optional arguments in typescript definitions

### DIFF
--- a/assets/js/live_svelte/types.d.ts
+++ b/assets/js/live_svelte/types.d.ts
@@ -1,6 +1,6 @@
 export type Live = {
-    pushEvent(event: string, payload: object, onReply: (reply: any, ref: number) => void): number
-    pushEventTo(phxTarget: any, event: string, payload: object, onReply: (reply: any, ref: number) => void): number
+    pushEvent(event: string, payload?: object, onReply?: (reply: any, ref: number) => void): number
+    pushEventTo(phxTarget: any, event: string, payload?: object, onReply?: (reply: any, ref: number) => void): number
 
     handleEvent(event: string, callback: (payload: any) => void): Function
     removeHandleEvent(callbackRef: Function): void


### PR DESCRIPTION
Forgot to mark `payload` and `onReply` as optional.