### PR TITLE
Add socket prop to skip ssr for live mounts and navigation

### DIFF
--- a/example_project/lib/example_web/live/live_chat.ex
+++ b/example_project/lib/example_web/live/live_chat.ex
@@ -25,6 +25,7 @@ defmodule ExampleWeb.LiveExample6 do
         messages={@messages}
         name={@name}
         class="w-full h-full flex justify-center items-center"
+        socket={@socket}
       />
     </div>
     """

--- a/example_project/lib/example_web/live/live_counter_hybrid.ex
+++ b/example_project/lib/example_web/live/live_counter_hybrid.ex
@@ -6,7 +6,7 @@ defmodule ExampleWeb.LiveExample3 do
     ~H"""
     <h1 class="flex justify-center mb-10 font-bold">Hybrid: LiveView + Svelte</h1>
 
-    <.CounterHybrid number={@number} />
+    <.CounterHybrid number={@number} socket={@socket} />
     """
   end
 

--- a/example_project/lib/example_web/live/live_json.ex
+++ b/example_project/lib/example_web/live/live_json.ex
@@ -5,7 +5,7 @@ defmodule ExampleWeb.LiveJson do
     ~H"""
     <div class="flex gap-10">
       <div>
-        SSR: <.svelte name="LiveJson" live_json_props={%{big_data_set: @ljbig_data_set}} />
+        SSR: <.svelte name="LiveJson" live_json_props={%{big_data_set: @ljbig_data_set}} socket={@socket} />
       </div>
       <div>
         No SSR:

--- a/example_project/lib/example_web/live/live_light.ex
+++ b/example_project/lib/example_web/live/live_light.ex
@@ -11,8 +11,8 @@ defmodule ExampleWeb.LiveLights do
     ~H"""
     <div class="max-w-screen-xl mx-auto p-4 flex flex-col gap-4">
       <h1 class="text-center text-2xl font-light my-4">Light Bulb Controller</h1>
-      <.svelte name="LightStatusBar" props={%{brightness: @brightness}} />
-      <.svelte name="LightControllers" props={%{isOn: isOn?(@brightness)}} />
+      <.svelte name="LightStatusBar" props={%{brightness: @brightness}} socket={@socket} />
+      <.svelte name="LightControllers" props={%{isOn: isOn?(@brightness)}} socket={@socket} />
     </div>
     """
   end

--- a/example_project/lib/example_web/live/live_log_list.ex
+++ b/example_project/lib/example_web/live/live_log_list.ex
@@ -3,7 +3,7 @@ defmodule ExampleWeb.LiveExample4 do
 
   def render(assigns) do
     ~H"""
-    <.svelte name="LogList" props={%{items: @items}} />
+    <.svelte name="LogList" props={%{items: @items}} socket={@socket} />
     """
   end
 

--- a/example_project/lib/example_web/live/live_simple_counter.ex
+++ b/example_project/lib/example_web/live/live_simple_counter.ex
@@ -15,7 +15,7 @@ defmodule ExampleWeb.LiveExample2 do
       </div>
       <div class="bg-[#eee] rounded p-2 m-2 w-[fit-content]">
         <h1 class="text-xs font-bold flex items-end justify-end">LiveSvelte</h1>
-        <.svelte name="SimpleCounter" props={%{number: @number}} />
+        <.svelte name="SimpleCounter" props={%{number: @number}} socket={@socket} />
       </div>
     </div>
     """

--- a/example_project/lib/example_web/live/live_slots_experiment.ex
+++ b/example_project/lib/example_web/live/live_slots_experiment.ex
@@ -3,7 +3,7 @@ defmodule ExampleWeb.LiveSlotsExperiment do
 
   def render(assigns) do
     ~H"""
-    <.svelte name="SlotsExperiment">
+    <.svelte name="SlotsExperiment" socket={@socket}>
       Inside Slot
     </.svelte>
     """

--- a/example_project/lib/example_web/live/live_struct.ex
+++ b/example_project/lib/example_web/live/live_struct.ex
@@ -11,7 +11,7 @@ defmodule ExampleWeb.LiveStruct do
   def render(assigns) do
     ~H"""
     <h1 class="text-lg">An example of how to pass a struct to Svelte:</h1>
-    <.svelte name="Struct" props={%{struct: @struct}} />
+    <.svelte name="Struct" props={%{struct: @struct}} socket={@socket} />
     """
   end
 

--- a/lib/components.ex
+++ b/lib/components.ex
@@ -23,25 +23,21 @@ defmodule LiveSvelte.Components do
   defp name_to_function(name) do
     quote do
       def unquote(:"#{name}")(assigns) do
-        props =
-          assigns
-          |> Map.filter(fn
-            {:svelte_opts, _v} -> false
-            {k, _v} -> k not in [:__changed__, :__given__, :ssr]
-            _ -> false
-          end)
+        props = Map.drop(assigns, [:__changed__, :__given__, :ssr, :class, :socket])
 
         var!(assigns) =
           assigns
           |> Map.put(:__component_name, unquote(name))
           |> Map.put_new(:ssr, true)
           |> Map.put_new(:class, nil)
+          |> Map.put_new(:socket, nil)
           |> assign(:props, props)
 
         ~H"""
         <LiveSvelte.svelte
           name={@__component_name}
           class={@class}
+          socket={@socket}
           ssr={@ssr}
           props={@props}
         />


### PR DESCRIPTION
Closes #73.

Added `socket` prop and updated views in example project to use it. Sigil uses it automatically.

Removed `get_ssr` util method.

In generated live components `class` was not removed from props and `svelte_opts` were even though they are not used there. Fixed.