### PR TITLE
Implement SSR behaviour

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,8 @@
 import Config
 
+config :live_svelte, 
+  ssr_module: LiveSvelte.SSR.NodeJS
+
 if Mix.env() == :dev do
   esbuild = fn args ->
     [

--- a/example_project/lib/example/application.ex
+++ b/example_project/lib/example/application.ex
@@ -8,7 +8,7 @@ defmodule Example.Application do
   @impl true
   def start(_type, _args) do
     children = [
-      {NodeJS.Supervisor, [path: LiveSvelte.SSR.server_path(), pool_size: 4]},
+      {NodeJS.Supervisor, [path: LiveSvelte.SSR.NodeJS.server_path(), pool_size: 4]},
       # Start the Telemetry supervisor
       ExampleWeb.Telemetry,
       # Start the Ecto repository

--- a/lib/component.ex
+++ b/lib/component.ex
@@ -81,7 +81,7 @@ defmodule LiveSvelte do
 
           SSR.render(assigns.name, props, slots)
         rescue
-          SSR.NodeNotConfigured -> nil
+          SSR.NotConfigured -> nil
         end
       end
 

--- a/lib/mix/tasks/configure_phoenix.ex
+++ b/lib/mix/tasks/configure_phoenix.ex
@@ -39,7 +39,7 @@ defmodule Mix.Tasks.LiveSvelte.ConfigurePhoenix do
 
   defp configure_application() do
     text = ~s"""
-    {NodeJS.Supervisor, [path: LiveSvelte.SSR.server_path(), pool_size: 4]},\
+    {NodeJS.Supervisor, [path: LiveSvelte.SSR.NodeJS.server_path(), pool_size: 4]},\
     """
 
     {path, file} = path_and_file("lib/**/", "application.ex")

--- a/lib/ssr.ex
+++ b/lib/ssr.ex
@@ -1,10 +1,7 @@
-defmodule LiveSvelte.SSR.NodeNotConfigured do
+defmodule LiveSvelte.SSR.NotConfigured do
   @moduledoc false
 
-  defexception message: """
-                 NodeJS is not configured. Please add the following to your application.ex:
-                 {NodeJS.Supervisor, [path: LiveSvelte.SSR.server_path(), pool_size: 4]},
-               """
+  defexception [:message]
 end
 
 defmodule LiveSvelte.SSR do

--- a/lib/ssr/node_js.ex
+++ b/lib/ssr/node_js.ex
@@ -6,7 +6,12 @@ defmodule LiveSvelte.SSR.NodeJS do
     try do
       NodeJS.call!({"server", "render"}, [name, props, slots])
     catch
-      :exit, {:noproc, _} -> raise LiveSvelte.SSR.NodeNotConfigured
+      :exit, {:noproc, _} ->
+        message = """
+        NodeJS is not configured. Please add the following to your application.ex:
+        {NodeJS.Supervisor, [path: LiveSvelte.SSR.NodeJS.server_path(), pool_size: 4]},
+        """
+        raise %LiveSvelte.SSR.NotConfigured{message: message}
     end
   end
 

--- a/lib/ssr/node_js.ex
+++ b/lib/ssr/node_js.ex
@@ -1,0 +1,17 @@
+defmodule LiveSvelte.SSR.NodeJS do
+  @moduledoc false
+  @behaviour LiveSvelte.SSR
+
+  def render(name, props, slots) do
+    try do
+      NodeJS.call!({"server", "render"}, [name, props, slots])
+    catch
+      :exit, {:noproc, _} -> raise LiveSvelte.SSR.NodeNotConfigured
+    end
+  end
+
+  def server_path() do
+    {:ok, path} = :application.get_application()
+    Application.app_dir(path, "/priv/svelte")
+  end
+end

--- a/test/ssr_test.exs
+++ b/test/ssr_test.exs
@@ -6,6 +6,13 @@ defmodule LiveSvelte.SSRTest do
     assert Application.get_env(:live_svelte, :ssr_module) == LiveSvelte.SSR.NodeJS
   end
 
+  test "Node.js raises the correct exception" do
+    load_config("config/config.exs")
+    assert_raise(LiveSvelte.SSR.NotConfigured, fn -> 
+      LiveSvelte.SSR.NodeJS.render("Test", %{}, %{})
+    end)
+  end
+
   test "It uses a different SSR module" do
     load_config("test/ssr_test/test_config.exs")
     assert Application.get_env(:live_svelte, :ssr_module) == SomeOtherSSRModule

--- a/test/ssr_test.exs
+++ b/test/ssr_test.exs
@@ -1,0 +1,26 @@
+defmodule LiveSvelte.SSRTest do
+  use ExUnit.Case, async: false # must be synchronous, tests are sensitive to config changes
+
+  test "Node.js is used by default for SSR" do
+    load_config("config/config.exs")
+    assert Application.get_env(:live_svelte, :ssr_module) == LiveSvelte.SSR.NodeJS
+  end
+
+  test "It uses a different SSR module" do
+    load_config("test/ssr_test/test_config.exs")
+    assert Application.get_env(:live_svelte, :ssr_module) == SomeOtherSSRModule
+  end
+
+  # evil
+  # "reloads" configuration by taking all current application configs
+  # and merging them with the newly-loaded config file and stuffing
+  # them back into the application env
+  defp load_config(path) do
+    Application.started_applications(:infinity)
+    |> Enum.reduce([], fn {app, _, _}, acc ->
+      [{app, Application.get_all_env(app)} | acc]
+    end)
+    |> Config.Reader.merge(Config.Reader.read!(path))
+    |> Application.put_all_env()
+  end
+end

--- a/test/ssr_test/test_config.exs
+++ b/test/ssr_test/test_config.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :live_svelte, ssr_module: SomeOtherSSRModule


### PR DESCRIPTION
To facilitate the creation of alternative SSR behaviours, the the implementation-specific code is relocated into its own module. This is backwards compatible, but will emit a deprecation warning. There are also some basic tests to verify that we default to NodeJS for backwards compatibility.

I've also started working on a subproject to do end-to-end testing, but would like to iron out any concerns here before moving on to that. 

Partially addresses what was discussed in #81 