### PR TITLE
Run setup tasks synchronously

### DIFF
--- a/lib/mix/tasks/setup.ex
+++ b/lib/mix/tasks/setup.ex
@@ -11,8 +11,10 @@ defmodule Mix.Tasks.LiveSvelte.Setup do
       "configure_phoenix",
       "configure_esbuild"
     ]
-    |> Enum.map(&Task.async(fn -> Mix.Task.run("live_svelte." <> &1) end))
-    |> Enum.map(&Task.await(&1, :infinity))
+    |> Enum.map(
+      &(Task.async(fn -> Mix.Task.run("live_svelte." <> &1) end)
+        |> Task.await(:infinity))
+    )
 
     log_success("live_svelte setup finished.")
   end


### PR DESCRIPTION
## Summary

Change LiveSvelte setup tasks to run synchronously.

## Reason for change

Currently the setup tasks run asynchronously. However this could lead to jumbled terminal output such as in the following screenshot:

![Screenshot 2023-11-23 at 16 51 57](https://github.com/woutdp/live_svelte/assets/63323230/a4e5cb18-772a-411c-9e37-ccd2c0813219)

This is not ideal because the user installing `live_svelte` may miss the prompt for the file overwrite and think that the process just hung. (This is what happened to me and it took a while to figure out what was wrong 😅). Changing the setup tasks to run synchronously will show a clearer output to the user:

![Screenshot 2023-11-23 at 17 02 18](https://github.com/woutdp/live_svelte/assets/63323230/31c25f34-b914-49a9-a961-39aa85d10bff)
