### PR TITLE
Explicitly set npm install folder

### DIFF
--- a/lib/mix/tasks/install_npm_deps.ex
+++ b/lib/mix/tasks/install_npm_deps.ex
@@ -8,9 +8,8 @@ defmodule Mix.Tasks.LiveSvelte.InstallNpmDeps do
   def run(_) do
     log_info("-- Installing npm dependencies...")
 
-    "cd assets &&
-    npm install --save-dev esbuild@^0.16.17 esbuild-svelte svelte svelte-preprocess esbuild-plugin-import-glob &&
-    npm install --save ../deps/phoenix ../deps/phoenix_html ../deps/phoenix_live_view ../deps/live_svelte"
+    "npm install --prefix ./assets --save-dev esbuild@^0.16.17 esbuild-svelte svelte svelte-preprocess esbuild-plugin-import-glob &&
+     npm install --prefix ./assets --save ./deps/phoenix ./deps/phoenix_html ./deps/phoenix_live_view ./deps/live_svelte"
     |> String.to_charlist()
     |> :os.cmd()
     |> IO.puts()


### PR DESCRIPTION
## Summary

Explicitly set the folder for `npm` install in using the [`--prefix`](https://docs.npmjs.com/cli/v10/using-npm/config#prefix) flag to prevent installation into the wrong folder.

## Reason for change

In the current `install_npm_deps` script, we `cd` into the `assets` folder then perform the installation. This won't always work because if a `package.json` does not already exist in the `assets` folder, `npm` will look for the nearest parent folder containing either a `package.json` file or a `node_modules` folder and do the installation there.

Using the `--prefix` flag will force installation in the specified folder.