### PR TITLE
Add `tailwind default --minify` to  `assets.deploy` alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,12 @@ defp aliases do
   [
     setup: ["deps.get", "ecto.setup", "cmd --cd assets npm install"],
     ...,
-    "assets.deploy": ["cmd --cd assets node build.js --deploy", "phx.digest"]
+    "assets.deploy": ["tailwind default --minify", "cmd --cd assets node build.js --deploy", "phx.digest"]
   ]
 end
 ```
+
+Note: `tailwind default --minify` is only required in the `assets.deploy` alias if you're using Tailwind. If you are not using Tailwind, you can remove it from the list.
 
 3. Run the following in your terminal
 


### PR DESCRIPTION
## Summary

Update README to include `tailwind default --minify` in  `assets.deploy` alias.

## Reason for change

During dev, the Tailwind watcher in `config/dev.exs` will build CSS. However in deployment, the CSS will not be built if `tailwind default --minify` is not included in the deployment script. Since Phoenix supports Tailwind by default, it might be a good idea to keep the Tailwind build command by default and just have a note to let users know they don't need it if not using Tailwind.

