### PR TITLE
Add deployment section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Svelte inside Phoenix LiveView with seamless end-to-end reactivity
 [Resources](#resources) •
 [Demo](#demo) •
 [Installation](#installation) •
-[Usage](#usage)
+[Usage](#usage) •
+[Deployment](#deployment) 
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -624,6 +624,90 @@ Run:
 mix hex.publish
 ```
 
+## Deployment
+
+Deploying a LiveSvelte app is the same as deploying a regular Phoenix app, except that you will need to ensure that `nodejs` (version 19 or later) is installed in your production environment. 
+
+The below guide shows how to deploy a LiveSvelte app to [Fly.io](https://fly.io/), but similar steps can be taken to deploy to other hosting providers.
+You can find more information on how to deploy a Phoenix app [here](https://hexdocs.pm/phoenix/deployment.html).
+
+### Deploying on Fly.io
+
+The following steps are needed to deploy to Fly.io. This guide assumes that you'll be using Fly Postgres as your database. Further guidance on how to deploy to Fly.io can be found [here](https://fly.io/docs/elixir/getting-started/).
+
+1. Generate a `Dockerfile`:
+
+```bash
+mix phx.gen.release --docker
+```
+
+2. Modify the generated `Dockerfile` to install `curl`, which is used to install `nodejs` (version 19 or greater), and also add a step to install our `npm` dependencies:
+
+```diff
+# ./Dockerfile
+
+...
+
+# install build dependencies
+- RUN apt-get update -y && apt-get install -y build-essential git \
++ RUN apt-get update -y && apt-get install -y build-essential git curl \
+    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
++ # install nodejs for build stage
++ RUN curl -fsSL https://deb.nodesource.com/setup_19.x | bash - && apt-get install -y nodejs
+
+...
+
+COPY assets assets
+
++ # install all npm packages in assets directory
++ WORKDIR /app/assets
++ RUN npm install
+
++ # change back to build dir
++ WORKDIR /app
+
+...
+
+# start a new build stage so that the final image will only contain
+# the compiled release and other runtime necessities
+FROM ${RUNNER_IMAGE}
+
+RUN apt-get update -y && \
+-  apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
++  apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates curl \
+   && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
++ # install nodejs for production environment
++ RUN curl -fsSL https://deb.nodesource.com/setup_19.x | bash - && apt-get install -y nodejs
+
+...
+```
+
+Note: `nodejs` is installed BOTH in the build stage and in the final image. This is because we need `nodejs` to install our `npm` dependencies and also need it when running our app. 
+
+3. Launch your app with the Fly.io CLI:
+
+```bash
+fly launch
+```
+
+4. When prompted to tweak settings, choose `y`:
+
+```bash
+? Do you want to tweak these settings before proceeding? (y/N) y
+```
+
+This will launch a new window where you can tweak your launch settings. In the database section, choose `Fly Postgres` and enter a name for your database. You may also want to change your database to the development configuration to avoid extra costs. You can leave the rest of the settings as-is unless you want to change them.
+
+Deployment will continue once you hit confirm.
+
+5. Once the deployment completes, run the following command to see your deployed app! 
+
+```bash
+fly apps open
+```
+
 ## Credits
 
 -   [Ryan Cooke](https://dev.to/debussyman) - [E2E Reactivity using Svelte with Phoenix LiveView](https://dev.to/debussyman/e2e-reactivity-using-svelte-with-phoenix-liveview-38mf)


### PR DESCRIPTION
## Summary

Add a Deployment section to the README with a guide on how to deploy a LiveSvelte app to Fly.io.

## Reason for change

As a user, I would like to know how to deploy my apps. Deployment of a LiveSvelte app is more involved than deploying a regular Phoenix app since it requires `nodejs` to be available in production. Having a guide to help users with deployment may help with adoption of LiveSvelte.