### PR TITLE
properly encode server components

### DIFF
--- a/lib/ssr/node_js.ex
+++ b/lib/ssr/node_js.ex
@@ -4,13 +4,14 @@ defmodule LiveSvelte.SSR.NodeJS do
 
   def render(name, props, slots) do
     try do
-      NodeJS.call!({"server", "render"}, [name, props, slots])
+      NodeJS.call!({"server", "render"}, [name, props, slots], binary: true)
     catch
       :exit, {:noproc, _} ->
         message = """
         NodeJS is not configured. Please add the following to your application.ex:
         {NodeJS.Supervisor, [path: LiveSvelte.SSR.NodeJS.server_path(), pool_size: 4]},
         """
+
         raise %LiveSvelte.SSR.NotConfigured{message: message}
     end
   end


### PR DESCRIPTION
This is a fix for behaviour described in https://github.com/woutdp/live_svelte/issues/103

Svelte is by default using unicode escape encoding for non ASCII. This gets garbled in LiveSvelte.SSR.NodeJS.render unless we send binary option to NodeJS.call! 

I wish I saw this before I stumbled on solution :)

<img width="950" alt="Screenshot 2024-01-11 at 11 25 04" src="https://github.com/woutdp/live_svelte/assets/32063/8895741a-d61d-41c0-acdc-2ae7c5891741">

