### PR TITLE
Raise when Jason.encode/1 fails on props

### DIFF
--- a/lib/component.ex
+++ b/lib/component.ex
@@ -122,12 +122,7 @@ defmodule LiveSvelte do
   end
 
   defp json(props) do
-    props
-    |> Jason.encode()
-    |> case do
-      {:ok, encoded} -> encoded
-      {:error, _} -> ""
-    end
+    Jason.encode!(props)
   end
 
   defp id(name), do: "#{name}-#{System.unique_integer([:positive])}"


### PR DESCRIPTION
When passing in props that fails to Jason.encode, raise. (Prior behavior was to fail silently.)