### PR TITLE
Add to 'LiveSvelte Projects' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,5 +730,6 @@ fly apps open
 
 -   [Territoriez.io](https://territoriez.io)
 -   [ash-svelte-flowbite](https://github.com/dev-guy/ash-svelte-flowbite)
+-   [Local-First Todo App](https://github.com/tonydangblog/liveview-svelte-pwa)
 
 _Using LiveSvelte in a public project? Let me know and I'll add it to this list!_


### PR DESCRIPTION
I built a local-first to-do app with LiveSvelte :)

Source code: https://github.com/tonydangblog/liveview-svelte-pwa
Video presentation: https://www.youtube.com/watch?v=PX9-lq0LL9Q
Live demo: https://liveview-svelte-pwa.fly.dev/