### PR TITLE
Make Installation instruction platform agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ end
 ```elixir
 defp aliases do
   [
-    setup: ["deps.get", "ecto.setup", "cmd --cd assets npm install"],
+    setup: ["deps.get", "ecto.setup", "npm install --prefix assets"],
     ...,
-    "assets.deploy": ["tailwind default --minify", "cmd --cd assets node build.js --deploy", "phx.digest"]
+    "assets.deploy": ["tailwind default --minify", "node build.js --deploy --prefix assets", "phx.digest"]
   ]
 end
 ```


### PR DESCRIPTION
The lines to replace the esbuild with were specific to a Windows environment, calling `cmd`

This patch replaces these calls with the npm and node commands with the `--prefix` option, allowing these commands to run on all platforms that run node or npm