### PR TITLE
Update setup guide in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,26 +99,12 @@ end
 
 2. Adjust the `setup` and `assets.deploy` aliases in `mix.exs`:
 
--   For Windows
-
 ```elixir
 defp aliases do
   [
     setup: ["deps.get", "ecto.setup", "cmd --cd assets npm install"],
     ...,
     "assets.deploy": ["tailwind <app_name> --minify", "cmd --cd assets node build.js --deploy", "phx.digest"]
-  ]
-end
-```
-
--   For Linux/MacOS
-
-```elixir
-defp aliases do
-  [
-    setup: ["deps.get", "ecto.setup", "npm install --prefix assets"],
-    ...,
-    "assets.deploy": ["tailwind <app_name> --minify", "node build.js --deploy --prefix assets", "phx.digest"]
   ]
 end
 ```


### PR DESCRIPTION
It seems that mix alias should be the same on windows and unix systems.
https://elixirforum.com/t/doing-mix-assets-deploy-after-integrating-livesvelte/64985/11?u=wojciech