### PR TITLE
Update Neovim Treesitter config for newer syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,19 @@ To enable syntax highlighting in Neovim with Treesitter, create the following fi
 ; Svelte
 (sigil
   (sigil_name) @_sigil_name
+  (quoted_content) @injection.content
+ (#eq? @_sigil_name "V")
+ (#set! injection.language "svelte"))
+```
+
+For Neovim Treesitter version below v0.9:
+
+```
+; extends
+
+; Svelte
+(sigil
+  (sigil_name) @_sigil_name
   (quoted_content) @svelte
 (#eq? @_sigil_name "V"))
 ```


### PR DESCRIPTION
This PR updates the "Neovim Treesitter Config" section in README.md to include the new syntax introduced in nvim-treesitter/nvim-treesitter@78b54eb7f6a9956d25a3911fa0dfd0cabfe2a4c5