### PR TITLE
Fix type issue with exception

### DIFF
--- a/lib/mix/tasks/configure_phoenix.ex
+++ b/lib/mix/tasks/configure_phoenix.ex
@@ -18,7 +18,10 @@ defmodule Mix.Tasks.LiveSvelte.ConfigurePhoenix do
       configure_application()
       configure_gitignore()
     rescue
-      err -> log_error(err.message)
+      err ->
+        err
+        |> Exception.message()
+        |> log_error()
     end
 
     Mix.Task.run("format")


### PR DESCRIPTION
```elixir
Compiling 11 files (.ex)
    warning: unknown key .message in expression:

        err.message

    where "err" was given the type:

        # type: %{..., __exception__: true, __struct__: atom()}
        # from: lib/mix/tasks/configure_phoenix.ex:21
        rescue err ->

    hint: when you rescue without specifying exception names, the variable is assigned a type of a struct but all of its fields are unknown. If you are trying to access an exception's :message key, either specify the exception names or use `Exception.message/1`.

    typing violation found at:
    │
 21 │       err -> log_error(err.message)
    │                            ~~~~~~~
    │
    └─ lib/mix/tasks/configure_phoenix.ex:21:28: Mix.Tasks.LiveSvelte.ConfigurePhoenix.run/1
```