### PR TITLE
feat: <:loading /> slot for server-rendered markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ Use the `:loading` slot to render a placeholder during that gap:
 ```elixir
 <.svelte name="Example" ssr={false}>
   <:loading>
-    <p>This will show up while the Svelte component is being loaded</p>
+    <p>Until your LiveSvelte component renders client-side, this will be displayed</p>
   </:loading>
 </.svelte>
 ```

--- a/README.md
+++ b/README.md
@@ -631,6 +631,20 @@ Named slots also work:
 This works because of the Snippet API provided by Svelte. Be careful though, it's a new feature that might not be working 100% of the time, I'd love to see what limitations you hit with it. One limitation is that you can't slot other Svelte components.
 
 
+### Showing fallback content with :loading
+
+When SSR is disabled, a full‑page refresh briefly shows a blank content before Svelte finishes loading.
+Use the `:loading` slot to render a placeholder during that gap:
+
+```elixir
+<.svelte name="Example" ssr={false}>
+  <:loading>
+    <p>This will show up while the Svelte component is being loaded</p>
+  </:loading>
+</.svelte>
+```
+
+
 ## Caveats
 
 ### "Secret State"

--- a/assets/js/live_svelte/hooks.svelte.js
+++ b/assets/js/live_svelte/hooks.svelte.js
@@ -81,6 +81,11 @@ export function getHooks(components) {
                 window.addEventListener(`${liveJsonElement}_patched`, _event => update_state(this), false)
             }
 
+            // This is required for the loading slot to be cleared once we mount the component
+            if (!this.el.hasAttribute("data-ssr")) {
+                this.el.innerHTML = ""
+            }
+
             const hydrateOrMount = this.el.hasAttribute("data-ssr") ? hydrate : mount
 
             this._instance = hydrateOrMount(Component, {

--- a/example_project/assets/svelte/ClientSideLoading.svelte
+++ b/example_project/assets/svelte/ClientSideLoading.svelte
@@ -1,0 +1,1 @@
+<p>This is the component!</p>

--- a/example_project/lib/example_web/components/layouts/app.html.heex
+++ b/example_project/lib/example_web/components/layouts/app.html.heex
@@ -119,6 +119,12 @@
       >
         15
       </a>
+      <a
+        href={~p"/client-side-loading"}
+        class="font-semibold leading-6 text-zinc-900 hover:text-zinc-700 hover:underline p-2"
+      >
+        16
+      </a>
     </div>
 
     <div class="flex items-center gap-4">

--- a/example_project/lib/example_web/live/live_client_side_loading.ex
+++ b/example_project/lib/example_web/live/live_client_side_loading.ex
@@ -1,0 +1,29 @@
+defmodule ExampleWeb.LiveClientSideLoading do
+  use ExampleWeb, :live_view
+
+  def render(assigns) do
+    ~H"""
+    <h1 class="text-3xl bold mb-4">Examples of the loading slot</h1>
+    <div class="flex flex-col gap-4">
+      <div>
+        <h2 class="text-xl">Client side</h2>
+        <.svelte name="ClientSideLoading" ssr={false}>
+          <:loading>
+            <div class="animate-spin h-4 w-4 border-4 border-blue-500 rounded-full border-t-transparent"></div>
+          </:loading>
+        </.svelte>
+      </div>
+
+      <div>
+        <h2 class="text-xl">Server side (should not be used)</h2>
+        <p class="bold italic">This should flicker and throw a console warning</p>
+        <.svelte name="ClientSideLoading" socket={@socket}>
+          <:loading>
+            <div class="animate-spin h-4 w-4 border-4 border-blue-500 rounded-full border-t-transparent"></div>
+          </:loading>
+        </.svelte>
+      </div>
+    </div>
+    """
+  end
+end

--- a/example_project/lib/example_web/router.ex
+++ b/example_project/lib/example_web/router.ex
@@ -34,6 +34,7 @@ defmodule ExampleWeb.Router do
     live "/slots-simple", LiveSlotsSimple
     live "/slots-dynamic", LiveSlotsDynamic
     live "/composition", LiveComposition
+    live "/client-side-loading", LiveClientSideLoading
   end
 
   # Other scopes may use custom stacks.

--- a/lib/live_svelte.ex
+++ b/lib/live_svelte.ex
@@ -56,6 +56,13 @@ defmodule LiveSvelte do
     dead = assigns.socket == nil or not LiveView.connected?(assigns.socket)
     ssr_active = Application.get_env(:live_svelte, :ssr, true)
 
+    if init and ssr_active and assigns.ssr and assigns.loading != [] do
+      IO.warn(
+        "The loading slot is incompatible with server-side rendering (ssr). Either remove the loading slot or disable ssr",
+        Macro.Env.stacktrace(__ENV__)
+      )
+    end
+
     slots =
       assigns
       |> Slots.rendered_slot_map()

--- a/lib/live_svelte.ex
+++ b/lib/live_svelte.ex
@@ -44,6 +44,10 @@ defmodule LiveSvelte do
 
   slot :inner_block, doc: "Inner block of the Svelte component"
 
+  slot(:loading,
+    doc: "LiveView rendered markup to show while the component is loading client-side"
+  )
+
   @doc """
   Renders a Svelte component on the server.
   """
@@ -101,6 +105,7 @@ defmodule LiveSvelte do
           <%= raw(@ssr_render["css"]["code"]) %>
         </style>
         <%= raw(@ssr_render["html"]) %>
+        <%= render_slot(@loading) %>
       </div>
     </.live_json>
     """

--- a/lib/live_svelte.ex
+++ b/lib/live_svelte.ex
@@ -58,7 +58,7 @@ defmodule LiveSvelte do
 
     if init and ssr_active and assigns.ssr and assigns.loading != [] do
       IO.warn(
-        "The loading slot is incompatible with server-side rendering (ssr). Either remove the loading slot or disable ssr",
+        "The <:loading /> slot is incompatible with server-side rendering (ssr). Either remove the <:loading /> slot or set ssr={false}",
         Macro.Env.stacktrace(__ENV__)
       )
     end


### PR DESCRIPTION
Adds a new slot called `<:loading />` that allows a user to server render markup to display while waiting for the Svelte component to mount on the client.

This is useful if you want to display default markup to prevent the page from jumping once the client mounts, or to indicate to the user that something is loading.

- [x] Integrate with front-end and ensure it is removed after loading
- and through updates
- [x] Consider raising if you have `ssr: true`
- [x] Update documentation
- [x] Add tests

Closes #166