### PR TITLE
Fix example project installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,14 +214,19 @@ I recommend cloning `live_svelte` and running the example project in `/example_p
 
 ```
 git clone https://github.com/woutdp/live_svelte.git
-mix assets.build
-cd ./live_svelte/example_project
-npm install --prefix assets
+# compile live_svelte
+cd live_svelte
 mix deps.get
+npm install --prefix assets
+mix assets.build
+# set up and run the example project
+cd example_project
+mix deps.get
+npm install --prefix assets
 mix phx.server
 ```
 
-Server should be running on `localhost:4000`
+Server will be running on `localhost:4000`. If you want to change the port, edit `example_project/config/dev.exs` and change the `http` config.
 
 If you have examples you want to add, feel free to create a PR, I'd be happy to add them.
 

--- a/example_project/lib/example/application.ex
+++ b/example_project/lib/example/application.ex
@@ -11,8 +11,8 @@ defmodule Example.Application do
       {NodeJS.Supervisor, [path: LiveSvelte.SSR.NodeJS.server_path(), pool_size: 4]},
       # Start the Telemetry supervisor
       ExampleWeb.Telemetry,
-      # Start the Ecto repository
-      Example.Repo,
+      # Start the Ecto repository (actually not used in this example, so skip it)
+      # Example.Repo,
       # Start the PubSub system
       {Phoenix.PubSub, name: Example.PubSub},
       # Start Finch


### PR DESCRIPTION
I've fixed the installation instructions for the `example_project` since they didn't work.  (OTOH they didn't make much sense either, so it was obvious that they were broken and I didn't lose a lot of time — we should count our blessings!)

While I was at it I removed the requirement to have a database, since nothing in the code uses one anyway and having the requirement sidetracked me when I was trying to get the example up and running.  I made a minimal change, so that if someone wants to use this as a playground and talk to a database it should be easy to re-activate.

I didn't see any instructions for contributions so I just created a PR.  If you want an issue ticket as well I can write one.

Thanks for a great plugin, I look forward to using it once I work out how!