### PR TITLE
update tsconfig with svelte doc recommendations

### DIFF
--- a/assets/copy/tsconfig.json
+++ b/assets/copy/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
+        "target": "es2022",
+        "isolatedModules": true,
         "verbatimModuleSyntax": true,
         "types": ["node"],
         "baseUrl": ".",

--- a/example_project/assets/tsconfig.json
+++ b/example_project/assets/tsconfig.json
@@ -1,5 +1,7 @@
 {
     "compilerOptions": {
+        "target": "es2022",
+        "isolatedModules": true,
         "verbatimModuleSyntax": true,
         "types": ["node"],
         "baseUrl": ".",


### PR DESCRIPTION
Looks like missing `target` makes svelte-preprocess bug out: https://github.com/sveltejs/svelte-preprocess/issues/667

Should be safe enough to default to the recommendations from the svelte docs: https://svelte.dev/docs/svelte/typescript#tsconfig.json-settings