### PR TITLE
Decode slots as UTF-8

### DIFF
--- a/assets/js/live_svelte/hooks.svelte.js
+++ b/assets/js/live_svelte/hooks.svelte.js
@@ -1,4 +1,4 @@
-import {normalizeComponents} from "./utils"
+import {decodeB64ToUTF8, normalizeComponents} from "./utils"
 import {mount, hydrate, unmount, createRawSnippet} from "svelte"
 
 function getAttributeJson(ref, attributeName) {
@@ -12,7 +12,7 @@ function getSlots(ref) {
     for (const slotName in getAttributeJson(ref, "data-slots")) {
         const base64 = getAttributeJson(ref, "data-slots")[slotName]
         const element = document.createElement("div")
-        element.innerHTML = atob(base64).trim()
+        element.innerHTML = decodeB64ToUTF8(base64).trim()
 
         const snippet = createRawSnippet(name => {
             return {

--- a/assets/js/live_svelte/utils.js
+++ b/assets/js/live_svelte/utils.js
@@ -9,3 +9,8 @@ export function normalizeComponents(components) {
     }
     return normalized
 }
+
+export function decodeB64ToUTF8(b64) {
+    const chars = Uint8Array.from(atob(b64), c => c.charCodeAt(0))
+    return new TextDecoder().decode(chars)
+}


### PR DESCRIPTION
I encountered an issue when passing unicode like emojis to slots inside a LiveView component. The issue lies on the decoding of the base-64 encoded string on the client using `atob`.

I looked into it and turns out that `atob` does decodes to `Latin-1` and not `UTF-8` therefore symbols like emojis do not render correctly.

This PR changes the decoding of slots to decode to `UTF-8`

For the given code:
```heex
<.svelte name="Test" socket={@socket}>
  <div class="prose">
    <h1>
      Should render emojis 
      <br />
      🚀🦊👍✅
    </h1>
  </div>
</.svelte>
```

The corresponding output:

| Before | After |
| --- | --- |
|<img width="835" height="288" alt="image" src="https://github.com/user-attachments/assets/d5fb43fa-3c52-4a34-a32f-be6006b0074e" /> | <img width="829" height="288" alt="image" src="https://github.com/user-attachments/assets/6d8931b0-8912-4dd4-b24a-0950b2cd4124" /> |