### PR TITLE
Add shadcn-svelte + Tailwind v4 integration guide to README

### DIFF
--- a/example_project/assets/js/app.js
+++ b/example_project/assets/js/app.js
@@ -21,17 +21,11 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
-import {createLiveJsonHooks} from "live_json"
 import {getHooks} from "live_svelte"
 import * as Components from "../svelte/**/*.svelte"
 
-const Hooks = {
-    ...createLiveJsonHooks(),
-    ...getHooks(Components),
-}
-
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, {hooks: getHooks(Components), params: {_csrf_token: csrfToken}})
 
 // Show progress bar on live navigation and form submits
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})

--- a/example_project/assets/package.json
+++ b/example_project/assets/package.json
@@ -2,12 +2,12 @@
     "devDependencies": {
         "@types/lodash": "^4.14.192",
         "dynamic-marquee": "^2.6.2",
-        "esbuild": "^0.24.0",
+        "esbuild": "^0.24.2",
         "esbuild-plugin-import-glob": "^0.1.1",
-        "esbuild-svelte": "^0.9.0",
+        "esbuild-svelte": "^0.9.4",
         "lodash": "^4.17.21",
         "stylus": "^0.55.0",
-        "svelte": "^5.19.8",
+        "svelte": "^5.46.0",
         "svelte-preprocess": "^6.0.3",
         "typescript": "^5.6.3"
     },


### PR DESCRIPTION
Documents the steps required to integrate shadcn-svelte components with LiveSvelte and upgrade from Tailwind CSS v3 to v4, including dependency installation, utility setup, path aliases, Tailwind v4 syntax migration, and component usage.