### PR TITLE
fix: remove deprecated default argument from LiveSvelte.Encoder protocol

### DIFF
--- a/lib/live_svelte.ex
+++ b/lib/live_svelte.ex
@@ -399,7 +399,7 @@ defmodule LiveSvelte do
   end
 
   # Encodes structs via LiveSvelte.Encoder so Jsonpatch can compare them.
-  defp encode_for_diff(struct) when is_struct(struct), do: LiveSvelte.Encoder.encode(struct)
+  defp encode_for_diff(struct) when is_struct(struct), do: LiveSvelte.Encoder.encode(struct, [])
   defp encode_for_diff(other), do: other
 
   # Returns the :id field of a map as the identity key for ID-based list diffing (Tier 3).

--- a/lib/live_svelte/encoder.ex
+++ b/lib/live_svelte/encoder.ex
@@ -29,7 +29,7 @@ defprotocol LiveSvelte.Encoder do
 
   @doc "Encodes a value to a JSON-compatible term (map, list, or primitive)."
   @spec encode(t(), opts()) :: any()
-  def encode(value, opts \\ [])
+  def encode(value, opts)
 end
 
 defimpl LiveSvelte.Encoder, for: Integer do


### PR DESCRIPTION
## What

Removes the deprecated default-argument protocol definition in `lib/live_svelte/encoder.ex`, fixing this compile-time deprecation on current Elixir:

```
warning: default arguments in protocol definitions is deprecated
 32 │   def encode(value, opts \\ [])
 └─ lib/live_svelte/encoder.ex:32: LiveSvelte.Encoder (module)

warning: protocols can only define functions without implementation via def/1, found: encode/1
  1 │ defprotocol LiveSvelte.Encoder do
 └─ lib/live_svelte/encoder.ex:1: LiveSvelte.Encoder (module)
```

## Why

`def encode(value, opts \\ [])` desugars into an implicit `encode/1` clause that forwards to `encode/2` — this is exactly the pattern Elixir now flags: default arguments (and the resulting extra clause) aren't supported in protocol definitions, which allow only a single bodiless `def` head per function name. This is a real deprecation from Elixir core (not a Dialyzer/type-checker nit) that will eventually become a hard compile error.

## Fix

Every `defimpl LiveSvelte.Encoder` block in this file already implements `encode/2` explicitly — `opts` is threaded through recursive calls for List/Map/struct encoding, form and changeset handling, etc. Nothing actually depended on the implicit `encode/1` default *except* the protocol declaration itself and one internal call site.

So the fix is minimal:

- `defprotocol LiveSvelte.Encoder` now declares only `def encode(value, opts)` (no default) — this matches the arity every `defimpl` already provides, so **no implementation block needed to change**.
- The one internal caller that relied on the implicit `encode/1` — `encode_for_diff/1` in `lib/live_svelte.ex` — now passes `[]` explicitly: `LiveSvelte.Encoder.encode(struct, [])`.

I also considered adding an explicit `encode/1` convenience wrapper inside the protocol body that forwards to `encode/2`, but `defprotocol`'s `def` macro only accepts bodiless function-head declarations (confirmed by trying it — `def encode(value), do: encode(value, [])` fails to compile inside a protocol with `undefined function def/2 (there is no such import)`). Moving the opts default to call sites is the standard fix for this warning pair.

No public `@derive`-based usage is affected (`@derive LiveSvelte.Encoder` / `{LiveSvelte.Encoder, only: [...]}` / `except: [...]}` all continue to work unchanged, since they only ever go through `encode/2`).

## Verification

- `mix compile --force` — clean, no more encoder deprecation warnings, nothing new introduced.
- `mix test` — full suite (231 tests) passes unchanged, including `test/live_svelte/encoder_test.exs` covering Integer/Float/String/Atom/List/Map/Date-Time family/struct-with-`@derive`/Phoenix.HTML.Form/Ecto.Changeset encoding.
- `mix format` — no formatting changes needed beyond the diff itself.

## Diff

```diff
--- a/lib/live_svelte/encoder.ex
+++ b/lib/live_svelte/encoder.ex
@@ -29,7 +29,7 @@ defprotocol LiveSvelte.Encoder do
 
   @doc "Encodes a value to a JSON-compatible term (map, list, or primitive)."
   @spec encode(t(), opts()) :: any()
-  def encode(value, opts \\ [])
+  def encode(value, opts)
 end

--- a/lib/live_svelte.ex
+++ b/lib/live_svelte.ex
@@ -399,7 +399,7 @@ defmodule LiveSvelte do
   # Encodes structs via LiveSvelte.Encoder so Jsonpatch can compare them.
-  defp encode_for_diff(struct) when is_struct(struct), do: LiveSvelte.Encoder.encode(struct)
+  defp encode_for_diff(struct) when is_struct(struct), do: LiveSvelte.Encoder.encode(struct, [])
   defp encode_for_diff(other), do: other
```